### PR TITLE
Improved how cluster_structural_equivalence handles isolates

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^CRAN-RELEASE$
 ^doc$
 ^Meta$
+^CRAN-SUBMISSION$

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ working/*
 /Meta/
 tests/testthat/Rplots.pdf
 .DS_Store
+CRAN-SUBMISSION

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: migraph
 Title: Multimodal and Multilevel Network Analysis
-Version: 0.8.12
-Date: 2021-12-18
+Version: 0.8.13
+Date: 2021-12-19
 Description: A set of tools that extend common social network analysis packages
    for analysing multimodal and multilevel networks.
    It includes functions for one- and two-mode (and sometimes three-mode) 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# migraph 0.8.13
+
+## Modelling
+
+* Closed #149 by adding extra column to node_tie_census in `cluster_structural_equivalence()` for isolates
+  - Note that this renders all isolates structurally equivalent
+
 # migraph 0.8.12
 
 ## Package

--- a/R/census.R
+++ b/R/census.R
@@ -117,7 +117,7 @@ NULL
 #' @rdname graph_census
 #' @references 
 #' Hollway, James, Alessandro Lomi, Francesca Pallotti, and Christoph Stadtfeld. 
-#' “\href{https://doi.org/10.1017/nws.2017.8}{Multilevel Social Spaces: The Network Dynamics of Organizational Fields}.” 
+#' “\doi{10.1017/nws.2017.8}{Multilevel Social Spaces: The Network Dynamics of Organizational Fields}.” 
 #' _Network Science_ 5, no. 2 (June 2017): 187–212.
 #' @source Alejandro Espinosa 'netmem'
 #' @examples 

--- a/R/cluster.R
+++ b/R/cluster.R
@@ -14,7 +14,9 @@ NULL
 #' @export
 cluster_structural_equivalence <- function(object){
   mat <- node_tie_census(object)
-  if(any(colSums(t(mat))==0)) stop("Please remove any isolates before using this function.")
+  if(any(colSums(t(mat))==0)){
+    mat <- cbind(mat, (colSums(t(mat))==0))
+  } 
   correlations <- cor(t(mat))
   dissimilarity <- 1 - correlations
   distances <- stats::as.dist(dissimilarity)

--- a/man/graph_census.Rd
+++ b/man/graph_census.Rd
@@ -32,6 +32,6 @@ graph_triad_census(ison_coleman)
 }
 \references{
 Hollway, James, Alessandro Lomi, Francesca Pallotti, and Christoph Stadtfeld.
-“\href{https://doi.org/10.1017/nws.2017.8}{Multilevel Social Spaces: The Network Dynamics of Organizational Fields}.”
+“\doi{10.1017/nws.2017.8}{Multilevel Social Spaces: The Network Dynamics of Organizational Fields}.”
 \emph{Network Science} 5, no. 2 (June 2017): 187–212.
 }


### PR DESCRIPTION
# Description

## Modelling

* Closed #149 by adding extra column to node_tie_census in `cluster_structural_equivalence()` for isolates
  - Note that this renders all isolates structurally equivalent

# Checklist:

- PR form
  - [x] This pull request has an informative title
  - [x] Description above itemizes changes under subtitles, e.g. "## Data""
  - [x] Any closed, fixed, or related issues are referenced and explained in the description above, e.g. "Fixed #0 by adding A"
  - [ ] Package builds on my OS without issues
- PR checks all pass for latest commit
  - [x] CodeFactor check: Package improves or maintains good style
  - [x] Package builds on Mac
  - [x] Package builds on Windows
  - [x] Package builds on Linux
  - [x] CodeCov check: Package improves or maintains good test coverage
- Documentation
  - [x] Any new or modified functions or data have roxygen style documentation in their .R scripts
  - [x] Any longer functions are commented inline so that it is easier to debug in the future
  - [x] PR description above and the NEWS.md file are aligned
  - [x] DESCRIPTION file version is bumped by the appropriate increment (major, minor, patch)
